### PR TITLE
Fix erorrs

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,7 @@ Requirements:
 * Python
 * MongoDB
 * Flask Framework http://flask.pocoo.org
+* PyMongo (pip install pymongo==2.8)
 * MongoEngine http://mongoengine.org
 * Flask Bcrypt extension for encrypting your login passwords (pip install flask-bcrypt)
 * Flash CSRF extension for protecting you app against cross-site forgery (pip install flask-csrf)

--- a/models.py
+++ b/models.py
@@ -17,6 +17,7 @@ class Post(Document):
     author = ReferenceField(User)
     tags = ListField(StringField(max_length=30))
     comments = ListField(EmbeddedDocumentField(Comment))
+    meta = {'allow_inheritance': True}
 
 class TextPost(Post):
     content = StringField()

--- a/myapp.py
+++ b/myapp.py
@@ -1,7 +1,7 @@
 from flask import Flask, request, session, g, redirect, url_for, abort, render_template, flash
 from models import *
-from flaskext.bcrypt import Bcrypt
-from flaskext.csrf import csrf
+from flask.ext.bcrypt import Bcrypt
+from flask.ext.csrf import csrf
 import logging
 
 app = Flask(__name__)


### PR DESCRIPTION
Mongoengine required pymongo version less then 3.0 (for example 2.8)
for Post class should be [enabled inheritance](https://mongoengine-odm.readthedocs.org/en/latest/tutorial.html#posts)
and typo in import flaskext > flask.ext
